### PR TITLE
Fix packaged macOS PDF sidecar load via library-validation entitlement

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -202,3 +202,29 @@ jobs:
           prerelease: true   # 关键：标记为预发布，不会触发用户更新弹窗
           projectPath: "./textlingo-desktop"
           args: ${{ matrix.args }}
+
+      - name: assert PDF sidecar entitlements (macos only)
+        if: startsWith(matrix.platform, 'macos-')
+        shell: bash
+        run: |
+          set -euo pipefail
+          APP=$(find textlingo-desktop/src-tauri/target -type d -name "*.app" -path "*/release/bundle/macos/*" | head -1)
+          if [ -z "$APP" ]; then echo "::error::No .app bundle found"; exit 1; fi
+          echo "App bundle: $APP"
+          SIDECAR="$APP/Contents/MacOS/openkoto-pdf-translator"
+          if [ ! -f "$SIDECAR" ]; then
+            echo "::error::PDF sidecar not found at $SIDECAR"
+            ls -la "$APP/Contents/MacOS" || true
+            exit 1
+          fi
+          echo "--- signature ---"
+          codesign -dvvv "$SIDECAR" 2>&1 | grep -iE "TeamIdentifier|Authority=|Signature" || true
+          echo "--- entitlements ---"
+          ENTS=$(codesign -d --entitlements - --xml "$SIDECAR" 2>/dev/null || codesign -d --entitlements - "$SIDECAR" 2>/dev/null || true)
+          echo "$ENTS"
+          if echo "$ENTS" | grep -q "disable-library-validation"; then
+            echo "OK: disable-library-validation present on PDF sidecar"
+          else
+            echo "::error::disable-library-validation entitlement missing on PDF sidecar — PDF translation will fail at runtime"
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,3 +203,29 @@ jobs:
           prerelease: false
           projectPath: "./textlingo-desktop"
           args: ${{ matrix.args }}
+
+      - name: assert PDF sidecar entitlements (macos only)
+        if: startsWith(matrix.platform, 'macos-')
+        shell: bash
+        run: |
+          set -euo pipefail
+          APP=$(find textlingo-desktop/src-tauri/target -type d -name "*.app" -path "*/release/bundle/macos/*" | head -1)
+          if [ -z "$APP" ]; then echo "::error::No .app bundle found"; exit 1; fi
+          echo "App bundle: $APP"
+          SIDECAR="$APP/Contents/MacOS/openkoto-pdf-translator"
+          if [ ! -f "$SIDECAR" ]; then
+            echo "::error::PDF sidecar not found at $SIDECAR"
+            ls -la "$APP/Contents/MacOS" || true
+            exit 1
+          fi
+          echo "--- signature ---"
+          codesign -dvvv "$SIDECAR" 2>&1 | grep -iE "TeamIdentifier|Authority=|Signature" || true
+          echo "--- entitlements ---"
+          ENTS=$(codesign -d --entitlements - --xml "$SIDECAR" 2>/dev/null || codesign -d --entitlements - "$SIDECAR" 2>/dev/null || true)
+          echo "$ENTS"
+          if echo "$ENTS" | grep -q "disable-library-validation"; then
+            echo "OK: disable-library-validation present on PDF sidecar"
+          else
+            echo "::error::disable-library-validation entitlement missing on PDF sidecar — PDF translation will fail at runtime"
+            exit 1
+          fi

--- a/textlingo-desktop/package.json
+++ b/textlingo-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openkoto-desktop",
   "private": true,
-  "version": "0.6.8",
+  "version": "0.6.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/textlingo-desktop/src-tauri/Cargo.lock
+++ b/textlingo-desktop/src-tauri/Cargo.lock
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "openkoto-desktop"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/textlingo-desktop/src-tauri/Cargo.toml
+++ b/textlingo-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openkoto-desktop"
-version = "0.6.8"
+version = "0.6.9"
 description = "OpenKoto Desktop - AI-powered Article Reader"
 authors = ["OpenKoto Team"]
 edition = "2021"

--- a/textlingo-desktop/src-tauri/entitlements.plist
+++ b/textlingo-desktop/src-tauri/entitlements.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!--
+      The PDF translator sidecar is a PyInstaller --onefile binary. At runtime it
+      unpacks an embedded Python.framework and many .so/.dylib files into a temp
+      dir and dlopen()s them. Those bundled libraries are signed by python.org /
+      ad-hoc, i.e. with a different Team ID than our Developer ID signature.
+      Under the Hardened Runtime, library validation rejects loading libraries
+      whose Team ID differs from the main executable ("have different Team IDs"),
+      which breaks PDF translation in the packaged/notarized app.
+
+      disable-library-validation lifts that restriction. The other two exceptions
+      cover dyld env vars and unsigned executable memory that the CPython runtime
+      and native deps (onnxruntime/opencv) rely on. All three are notarization-safe.
+    -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+</dict>
+</plist>

--- a/textlingo-desktop/src-tauri/tauri.conf.json
+++ b/textlingo-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenKoto Desktop",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "identifier": "com.openkoto.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",
@@ -50,6 +50,9 @@
       "binaries/yt-dlp",
       "binaries/ffmpeg",
       "binaries/openkoto-pdf-translator"
-    ]
+    ],
+    "macOS": {
+      "entitlements": "entitlements.plist"
+    }
   }
 }


### PR DESCRIPTION
The PDF translator sidecar is a PyInstaller --onefile binary that unpacks an embedded Python.framework (signed by python.org) at runtime. Under the notarized app's Hardened Runtime, library validation rejected loading a library whose Team ID differs from our Developer ID signature, breaking PDF translation ("have different Team IDs").

- Add entitlements.plist with com.apple.security.cs.disable-library-validation (plus dyld-env and unsigned-executable-memory exceptions) and wire it via bundle.macOS.entitlements so Tauri applies it to the sidecar at signing.
- Add a post-bundle CI assertion that the signed sidecar carries the entitlement, guarding against regressions.
- Bump desktop to v0.6.9.