### PR TITLE
Fix PDF translation for derived-base-URL providers (Kimi/Moonshot)

### DIFF
--- a/textlingo-desktop/package.json
+++ b/textlingo-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openkoto-desktop",
   "private": true,
-  "version": "0.6.9",
+  "version": "0.6.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/textlingo-desktop/pdf-sidecar/openkoto_pdf_translator/openkoto_translator.py
+++ b/textlingo-desktop/pdf-sidecar/openkoto_pdf_translator/openkoto_translator.py
@@ -26,6 +26,11 @@ OPENKOTO_PROVIDER_URLS = {
     "google-ai-studio": "https://generativelanguage.googleapis.com/v1beta/openai",
     "ollama": "http://localhost:11434/v1",
     "lmstudio": "http://localhost:1234/v1",
+    # Moonshot / Kimi (OpenAI-compatible). The desktop app derives these URLs at
+    # runtime, so the stored config often has no explicit base_url.
+    "moonshot": "https://api.moonshot.cn/v1",
+    "moonshot-cn": "https://api.moonshot.cn/v1",
+    "moonshot-global": "https://api.moonshot.ai/v1",
 }
 
 # Default models per provider
@@ -107,6 +112,11 @@ class OpenKotoTranslator(OpenAITranslator):
             self.add_cache_impact_parameters("temperature", self.options["temperature"])
             self.add_cache_impact_parameters("prompt", self.prompt("", self.prompttext))
         else:
+            if not base_url:
+                raise ValueError(
+                    f"Base URL is required for provider '{provider}'. "
+                    "Set via OPENKOTO_BASE_URL env var or config file."
+                )
             super().__init__(
                 lang_in=lang_in,
                 lang_out=lang_out,

--- a/textlingo-desktop/pdf-sidecar/openkoto_pdf_translator/translator.py
+++ b/textlingo-desktop/pdf-sidecar/openkoto_pdf_translator/translator.py
@@ -439,12 +439,15 @@ class OpenAITranslator(BaseTranslator):
     ):
         self.set_envs(envs)
         if not model:
-            model = self.envs["OPENAI_MODEL"]
+            model = self.envs.get("OPENAI_MODEL", "gpt-4o-mini")
         super().__init__(lang_in, lang_out, model, ignore_cache)
         self.options = {"temperature": 0}  # 随机采样可能会打断公式标记
+        # Use .get() so a subclass whose envs dict lacks the OPENAI_* keys (e.g.
+        # OpenKotoTranslator) does not crash with a cryptic KeyError; callers are
+        # expected to pass base_url/api_key explicitly in that case.
         self.client = openai.OpenAI(
-            base_url=base_url or self.envs["OPENAI_BASE_URL"],
-            api_key=api_key or self.envs["OPENAI_API_KEY"],
+            base_url=base_url or self.envs.get("OPENAI_BASE_URL", "https://api.openai.com/v1"),
+            api_key=api_key or self.envs.get("OPENAI_API_KEY"),
         )
         self.prompttext = prompt
         self.add_cache_impact_parameters("temperature", self.options["temperature"])

--- a/textlingo-desktop/src-tauri/Cargo.lock
+++ b/textlingo-desktop/src-tauri/Cargo.lock
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "openkoto-desktop"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/textlingo-desktop/src-tauri/Cargo.toml
+++ b/textlingo-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openkoto-desktop"
-version = "0.6.9"
+version = "0.6.10"
 description = "OpenKoto Desktop - AI-powered Article Reader"
 authors = ["OpenKoto Team"]
 edition = "2021"

--- a/textlingo-desktop/src-tauri/src/agent_worker.rs
+++ b/textlingo-desktop/src-tauri/src/agent_worker.rs
@@ -546,7 +546,7 @@ pub fn worker_event_log_entry(event: &WorkerEvent) -> Option<(WorkerLogLevel, St
     }
 }
 
-fn default_base_url(provider: &str) -> Option<&'static str> {
+pub fn default_base_url(provider: &str) -> Option<&'static str> {
     match provider {
         "openai" => Some(OPENAI_BASE_URL),
         "openrouter" => Some(OPENROUTER_BASE_URL),

--- a/textlingo-desktop/src-tauri/src/commands.rs
+++ b/textlingo-desktop/src-tauri/src/commands.rs
@@ -1,5 +1,5 @@
 use crate::agent_worker::{
-    resolve_runtime_provider_config, AgentWorkerManager, AgentWorkerStatusSnapshot,
+    default_base_url, resolve_runtime_provider_config, AgentWorkerManager, AgentWorkerStatusSnapshot,
 };
 use crate::ai_service::{get_ai_service, get_or_create_ai_service, AIServiceCache};
 use crate::ktv_export::{export_ktv_video, prepare_ktv_segments, KtvExportConfig, KtvExportResult};
@@ -3006,8 +3006,20 @@ pub async fn translate_pdf_document(
         ("OPENKOTO_MODEL", model.clone()),
     ];
 
-    if let Some(ref url) = base_url {
-        envs.push(("OPENKOTO_BASE_URL", url.clone()));
+    // Resolve the base URL with the same provider defaults used by the other AI
+    // features, so providers whose URL is derived rather than stored (e.g.
+    // Moonshot/Kimi) still work when the active model config has no explicit
+    // base_url. Without this the sidecar receives no OPENKOTO_BASE_URL and dies
+    // with `KeyError: 'OPENAI_BASE_URL'`.
+    let resolved_base_url = base_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .or_else(|| default_base_url(&provider).map(ToOwned::to_owned));
+
+    if let Some(url) = resolved_base_url {
+        envs.push(("OPENKOTO_BASE_URL", url));
     }
 
     let sidecar = pdf_sidecar::resolve_pdf_sidecar(&app_handle)

--- a/textlingo-desktop/src-tauri/tauri.conf.json
+++ b/textlingo-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenKoto Desktop",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "identifier": "com.openkoto.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
PDF translation crashed with `KeyError: 'OPENAI_BASE_URL'` for providers whose base URL is derived at runtime rather than stored in the model config (notably Moonshot/Kimi).

## Changes
- **Rust** `translate_pdf_document` now resolves `base_url` via the shared `default_base_url()` (covers Moonshot/Kimi and other known providers) before exporting `OPENKOTO_BASE_URL`. Made `default_base_url` public.
- **Sidecar** `openkoto_translator.py`: added Moonshot/Kimi to the provider→URL map and raise a clear error when an OpenAI-compatible provider has no resolvable base URL.
- **Sidecar** `translator.py`: `OpenAITranslator` reads `OPENAI_*` envs via `.get()` so a subclass without those keys no longer dies with a cryptic KeyError.
- Bump desktop to v0.6.10.

Verified: `python -m py_compile` OK, `cargo check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)