### PR TITLE
Hide PDF sidecar console window on Windows + bump v0.6.11

### DIFF
--- a/textlingo-desktop/package.json
+++ b/textlingo-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openkoto-desktop",
   "private": true,
-  "version": "0.6.10",
+  "version": "0.6.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/textlingo-desktop/src-tauri/Cargo.lock
+++ b/textlingo-desktop/src-tauri/Cargo.lock
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "openkoto-desktop"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/textlingo-desktop/src-tauri/Cargo.toml
+++ b/textlingo-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openkoto-desktop"
-version = "0.6.10"
+version = "0.6.11"
 description = "OpenKoto Desktop - AI-powered Article Reader"
 authors = ["OpenKoto Team"]
 edition = "2021"

--- a/textlingo-desktop/src-tauri/src/commands.rs
+++ b/textlingo-desktop/src-tauri/src/commands.rs
@@ -3045,11 +3045,13 @@ pub async fn translate_pdf_document(
 
     // 在插件目录下执行，以确保 Python 模块导入正确 (如果是 Dev 模式)
     // 或者对于 Prod 模式，通常也不影响
-    let result = Command::new(&cmd)
+    let mut command = Command::new(&cmd);
+    command
         .args(&args)
         .envs(envs.iter().map(|(k, v)| (*k, v.as_str())))
-        .current_dir(&plugin_dir) // 关键：设置工作目录为插件目录
-        .output();
+        .current_dir(&plugin_dir); // 关键：设置工作目录为插件目录
+    pdf_sidecar::hide_console_window(&mut command); // Windows: 避免弹出黑色 cmd 窗口
+    let result = command.output();
 
     match result {
         Ok(output) => {

--- a/textlingo-desktop/src-tauri/src/pdf_sidecar.rs
+++ b/textlingo-desktop/src-tauri/src/pdf_sidecar.rs
@@ -137,3 +137,20 @@ pub fn build_pdf_sidecar_command_for_dir(
     ]);
     Ok(command)
 }
+
+/// Suppress the console window that would otherwise flash on Windows when the
+/// PDF sidecar (a `console=True` PyInstaller binary) is spawned via
+/// `std::process::Command`. Tauri's shell plugin already does this for its own
+/// sidecars (ffmpeg/yt-dlp), so only this raw spawn needs it. No-op elsewhere.
+pub fn hide_console_window(command: &mut std::process::Command) {
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = command;
+    }
+}

--- a/textlingo-desktop/src-tauri/tauri.conf.json
+++ b/textlingo-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenKoto Desktop",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "identifier": "com.openkoto.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Changes
- **Windows**: PDF translation no longer flashes a black `cmd` window. The PDF sidecar is a `console=True` PyInstaller binary spawned via raw `std::process::Command`; added `pdf_sidecar::hide_console_window()` (`CREATE_NO_WINDOW` on Windows, no-op elsewhere) and applied it to the `translate_pdf_document` spawn. Tauri's shell plugin already does this for ffmpeg/yt-dlp.
- Bump desktop to v0.6.11.

Verified: `cargo check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)