### PR TITLE
Self-heal partial PDF asset cache + ensure output dir (v0.6.14)

### DIFF
--- a/textlingo-desktop/package.json
+++ b/textlingo-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openkoto-desktop",
   "private": true,
-  "version": "0.6.13",
+  "version": "0.6.14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/textlingo-desktop/pdf-sidecar/openkoto_pdf_translator/pdf2zh.py
+++ b/textlingo-desktop/pdf-sidecar/openkoto_pdf_translator/pdf2zh.py
@@ -83,7 +83,11 @@ def _seed_offline_assets() -> None:
                     continue
                 # get_cache_file_path creates the destination sub-folder for us.
                 dst = str(get_cache_file_path(name, sub_folder))
-                if os.path.exists(dst):
+                # Skip only if a *complete* copy already exists. A size mismatch
+                # means a previous run left a partial/corrupt download (the exact
+                # state that makes the first translation hang), so overwrite it
+                # with the known-good bundled asset instead of skipping.
+                if os.path.exists(dst) and os.path.getsize(dst) == os.path.getsize(src):
                     continue
                 shutil.copy2(src, dst)
                 print(

--- a/textlingo-desktop/src-tauri/Cargo.lock
+++ b/textlingo-desktop/src-tauri/Cargo.lock
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "openkoto-desktop"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/textlingo-desktop/src-tauri/Cargo.toml
+++ b/textlingo-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openkoto-desktop"
-version = "0.6.13"
+version = "0.6.14"
 description = "OpenKoto Desktop - AI-powered Article Reader"
 authors = ["OpenKoto Team"]
 edition = "2021"

--- a/textlingo-desktop/src-tauri/src/commands.rs
+++ b/textlingo-desktop/src-tauri/src/commands.rs
@@ -3000,6 +3000,10 @@ pub async fn translate_pdf_document(
         .map(|s| s.to_string_lossy().to_string())
         .unwrap_or_else(|| "output".to_string());
 
+    // The sidecar writes <stem>-mono.pdf / -dual.pdf into output_dir but does not
+    // create it; make sure it exists so writing the result never fails.
+    let _ = std::fs::create_dir_all(&output_dir);
+
     // 构建环境变量
     let mut envs: Vec<(&str, String)> = vec![
         ("OPENKOTO_PROVIDER", provider.clone()),

--- a/textlingo-desktop/src-tauri/tauri.conf.json
+++ b/textlingo-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenKoto Desktop",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "identifier": "com.openkoto.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Follow-up to v0.6.13 after full local end-to-end verification (frozen PyInstaller sidecar + bundled assets, cache cleared → seeding copies model+fonts, **zero network download**, progress 0→100%, output PDFs produced).

## Changes
- `_seed_offline_assets`: overwrite a cached asset when its size differs from the bundled one (don't skip on mere existence). A prior stuck run on a build without offline assets can leave a **partial/corrupt download** in `~/.cache/babeldoc`; skipping it made babeldoc re-download and hang at 0% again. Verified by planting a truncated model — it gets restored and translation succeeds.
- `translate_pdf_document`: `create_dir_all(output_dir)` before spawn so writing result PDFs never fails.
- Bump to v0.6.14.

Verified: py_compile, cargo check, plus real runs of the frozen sidecar (fresh cache, corrupt cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)